### PR TITLE
Remove .vscode from repository

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,1 +1,0 @@
-{ "recommendations": ["expo.vscode-expo-tools"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "source.organizeImports": "explicit",
-    "source.sortMembers": "explicit"
-  }
-}


### PR DESCRIPTION
Abrí este PR para arreglar este detalle del archivo .vscode que no se ignoró en el anterior  PR de "clean up Expo base project", que por buenas prácticas no debería aparecer en main.